### PR TITLE
Update python_version for 3.13

### DIFF
--- a/junipersrx.json
+++ b/junipersrx.json
@@ -12,7 +12,7 @@
     "product_name": "Juniper SRX",
     "product_version_regex": ".*",
     "min_phantom_version": "6.3.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "Junos Version 21.2R1.10"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)